### PR TITLE
feat(common): add shared types, config schema, and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
             echo "No Python requirements files found; skipping pip-audit."
           fi
 
+
   unit_tests:
     name: unit_tests
     runs-on: ubuntu-latest
@@ -106,13 +107,15 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Install API dev deps
+      - name: Install packages
         run: |
           python -m pip install --upgrade pip
+          pip install -e packages/common
           pip install -e apps/api[dev]
-      - name: pytest (apps/api)
-        run: pytest -q apps/api
-
+      - name: pytest (packages and api)
+        run: |
+          pytest -q packages/common packages/common/tests
+          pytest -q apps/api/tests/unit
   integration_tests:
     name: integration_tests
     runs-on: ubuntu-latest

--- a/config/config.schema.json
+++ b/config/config.schema.json
@@ -1,0 +1,55 @@
+{
+  "properties": {
+    "env": {
+      "default": "dev",
+      "enum": [
+        "dev",
+        "staging",
+        "prod"
+      ],
+      "title": "Env",
+      "type": "string"
+    },
+    "log_level": {
+      "default": "INFO",
+      "enum": [
+        "DEBUG",
+        "INFO",
+        "WARNING",
+        "ERROR"
+      ],
+      "title": "Log Level",
+      "type": "string"
+    },
+    "timezone": {
+      "default": "UTC",
+      "title": "Timezone",
+      "type": "string"
+    },
+    "app_name": {
+      "default": "kitepilot",
+      "title": "App Name",
+      "type": "string"
+    },
+    "version": {
+      "default": "0.1.0",
+      "title": "Version",
+      "type": "string"
+    },
+    "database_url": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional DB URL for consumers",
+      "title": "Database Url"
+    }
+  },
+  "title": "Settings",
+  "type": "object"
+}

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -1,0 +1,3 @@
+# Kitepilot Common
+
+Shared types, enums, errors, and config schema for Kitepilot.

--- a/packages/common/kitepilot_common/__init__.py
+++ b/packages/common/kitepilot_common/__init__.py
@@ -1,0 +1,23 @@
+from .enums import Side, OrderType, TimeInForce, OrderStatus
+from .types import Signal, OrderIntent, OrderState, Fees, Limits, ist_utc_pair
+from .errors import KitepilotError, ConfigError
+from .config import Settings, load_settings, schema_json
+
+__all__ = [
+    "Side",
+    "OrderType",
+    "TimeInForce",
+    "OrderStatus",
+    "Signal",
+    "OrderIntent",
+    "OrderState",
+    "Fees",
+    "Limits",
+    "ist_utc_pair",
+    "KitepilotError",
+    "ConfigError",
+    "Settings",
+    "load_settings",
+    "schema_json",
+]
+__version__ = "0.1.0"

--- a/packages/common/kitepilot_common/config.py
+++ b/packages/common/kitepilot_common/config.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+from typing import Any, Literal, Optional
+from pydantic import BaseModel, Field
+from .errors import ConfigError
+
+
+class Settings(BaseModel):
+    env: Literal["dev", "staging", "prod"] = "dev"
+    log_level: Literal["DEBUG", "INFO", "WARNING", "ERROR"] = "INFO"
+    timezone: str = "UTC"
+    app_name: str = "kitepilot"
+    version: str = "0.1.0"
+    database_url: Optional[str] = Field(default=None, description="Optional DB URL for consumers")
+
+
+def schema_json() -> dict[str, Any]:
+    """Return the JSON Schema dict that should be published for config."""
+    return Settings.model_json_schema()
+
+
+def load_settings(data: dict[str, Any] | None = None) -> Settings:
+    try:
+        return Settings(**(data or {}))
+    except Exception as exc:  # pragma: no cover
+        raise ConfigError(str(exc))

--- a/packages/common/kitepilot_common/enums.py
+++ b/packages/common/kitepilot_common/enums.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+from enum import Enum
+
+
+class Side(str, Enum):
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+class OrderType(str, Enum):
+    MARKET = "MARKET"
+    LIMIT = "LIMIT"
+
+
+class TimeInForce(str, Enum):
+    DAY = "DAY"
+    IOC = "IOC"
+    FOK = "FOK"
+    GTC = "GTC"
+
+
+class OrderStatus(str, Enum):
+    NEW = "NEW"
+    PARTIALLY_FILLED = "PARTIALLY_FILLED"
+    FILLED = "FILLED"
+    CANCELED = "CANCELED"

--- a/packages/common/kitepilot_common/errors.py
+++ b/packages/common/kitepilot_common/errors.py
@@ -1,0 +1,6 @@
+class KitepilotError(Exception):
+    """Base exception for Kitepilot libraries."""
+
+
+class ConfigError(KitepilotError):
+    """Configuration-related errors."""

--- a/packages/common/kitepilot_common/types.py
+++ b/packages/common/kitepilot_common/types.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Optional
+from pydantic import BaseModel, Field, ValidationInfo, field_validator
+from .enums import Side, OrderType, TimeInForce, OrderStatus
+
+IST = timezone(timedelta(hours=5, minutes=30))
+
+
+def ist_utc_pair(dt: datetime) -> tuple[datetime, datetime]:
+    """Return (ist, utc) aware datetimes for input dt.
+    If dt is naive, assume UTC.
+    """
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(IST), dt.astimezone(timezone.utc)
+
+
+class Signal(BaseModel):
+    symbol: str
+    side: Side
+    strength: float = Field(ge=0.0, le=1.0)
+    ts_ist: datetime
+    ts_utc: datetime
+
+    @field_validator("ts_utc")
+    @classmethod
+    def ensure_aware(cls, v: datetime) -> datetime:
+        return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
+
+
+class OrderIntent(BaseModel):
+    symbol: str
+    side: Side
+    qty: int = Field(gt=0)
+    order_type: OrderType = OrderType.MARKET
+    limit_price: Optional[Decimal] = None
+    tif: TimeInForce = TimeInForce.DAY
+
+    @field_validator("limit_price")
+    @classmethod
+    def price_required_for_limit(
+        cls, v: Optional[Decimal], info: ValidationInfo
+    ) -> Optional[Decimal]:
+        order_type = info.data.get("order_type")
+        if order_type == OrderType.LIMIT and v is None:
+            raise ValueError("limit_price required for LIMIT orders")
+        return v
+
+
+class Fees(BaseModel):
+    commission: Decimal = Decimal("0")
+    taxes: Decimal = Decimal("0")
+
+    @property
+    def total(self) -> Decimal:
+        return self.commission + self.taxes
+
+
+class Limits(BaseModel):
+    max_notional: Decimal = Field(gt=0)
+    max_positions: int = Field(gt=0)
+    max_risk_per_symbol: Decimal = Field(gt=0)
+
+
+class OrderState(BaseModel):
+    client_order_id: str
+    status: OrderStatus = OrderStatus.NEW
+    filled_qty: int = 0
+    avg_price: Optional[Decimal] = None

--- a/packages/common/pyproject.toml
+++ b/packages/common/pyproject.toml
@@ -1,0 +1,32 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "kitepilot-common"
+version = "0.1.0"
+description = "Shared types, enums, errors, and config schema for Kitepilot"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{name="Kitepilot"}]
+license = { text = "Apache-2.0" }
+keywords = ["trading", "fastapi", "pydantic", "types"]
+dependencies = [
+  "pydantic>=2.7,<3",
+  "typing-extensions>=4.10",
+  "pytz>=2024.1"
+]
+
+[tool.hatch.build]
+packages = ["kitepilot_common"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.black]
+line-length = 100
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+packages = ["kitepilot_common"]

--- a/packages/common/tests/unit/test_roundtrip.py
+++ b/packages/common/tests/unit/test_roundtrip.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+from decimal import Decimal
+from kitepilot_common import (
+    Side,
+    OrderType,
+    Signal,
+    OrderIntent,
+    OrderState,
+    Fees,
+    Limits,
+)
+
+
+def test_signal_roundtrip():
+    now = datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc)
+    s = Signal(symbol="BTCUSDT", side=Side.BUY, strength=0.8, ts_ist=now, ts_utc=now)
+    payload = s.model_dump_json()
+    again = Signal.model_validate_json(payload)
+    assert again == s
+
+
+def test_order_and_fees_limits():
+    oi = OrderIntent(symbol="AAPL", side=Side.SELL, qty=10, order_type=OrderType.MARKET)
+    st = OrderState(client_order_id="c1")
+    fees = Fees(commission=Decimal("1.25"), taxes=Decimal("0.75"))
+    lim = Limits(
+        max_notional=Decimal("100000"), max_positions=10, max_risk_per_symbol=Decimal("2500")
+    )
+    assert fees.total == Decimal("2.00")
+    assert st.status.value == "NEW"
+    assert oi.qty == 10 and lim.max_positions == 10

--- a/packages/common/tests/unit/test_schema_sync.py
+++ b/packages/common/tests/unit/test_schema_sync.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+import json
+from kitepilot_common import schema_json
+
+
+def test_schema_matches_published_file():
+    with open("config/config.schema.json", "r", encoding="utf-8") as f:
+        published = json.load(f)
+    assert published == schema_json()

--- a/packages/common/tests/unit/test_timezones.py
+++ b/packages/common/tests/unit/test_timezones.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+from datetime import datetime, timezone
+from kitepilot_common import ist_utc_pair
+
+
+def test_ist_utc_pair_converts_and_is_aware():
+    naive = datetime(2024, 1, 1, 0, 0, 0)  # assume UTC if naive
+    ist, utc = ist_utc_pair(naive)
+    assert ist.tzinfo is not None and utc.tzinfo is not None
+    assert utc.tzinfo is timezone.utc


### PR DESCRIPTION
## Summary
- add kitepilot-common package with enums, Pydantic models, timezone helpers, and config schema
- include tests for round-trip serialization, timezone helpers, and schema sync
- update CI to install and run tests for common package

## Testing
- `ruff check . && black --check . && mypy kitepilot_common`
- `pre-commit run --files .github/workflows/ci.yml config/config.schema.json packages/common/pyproject.toml packages/common/README.md packages/common/kitepilot_common/__init__.py packages/common/kitepilot_common/enums.py packages/common/kitepilot_common/errors.py packages/common/kitepilot_common/types.py packages/common/kitepilot_common/config.py packages/common/tests/unit/test_roundtrip.py packages/common/tests/unit/test_timezones.py packages/common/tests/unit/test_schema_sync.py`
- `pytest -q packages/common packages/common/tests`
- `pytest -q apps/api/tests/unit`


------
https://chatgpt.com/codex/tasks/task_e_68b20b0c262083309703776f14ee1787