### PR TITLE
feat(strategy-kit): interfaces, registry, and SMA example (T08)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,10 +52,12 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e apps/api[dev]
           pip install -e packages/feature-lib
-      - name: mypy (apps/api & feature-lib)
+          pip install -e packages/strategy-kit
+      - name: mypy (apps/api, feature-lib & strategy-kit)
         run: |
           mypy apps/api
           mypy packages/feature-lib
+          mypy packages/strategy-kit
 
   build:
     name: build
@@ -116,10 +118,12 @@ jobs:
           pip install -e packages/common
           pip install -e apps/api[dev]
           pip install -e packages/feature-lib
+          pip install -e packages/strategy-kit
       - name: pytest (packages and api)
         run: |
           pytest -q packages/common packages/common/tests
           pytest -q packages/feature-lib/tests
+          pytest -q packages/strategy-kit/tests
           pytest -q apps/api/tests/unit
   integration_tests:
     name: integration_tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,3 +17,9 @@ The format is based on Keep a Changelog, and this project adheres to Conventiona
 - md-gateway app with simulated ticks and 1s/1m bar aggregation.
 
 ### 2025-08-29 – T07: Feature library — Adds price/microstructure/volatility features with tests and docs.
+
+## [0.2.0] - 2025-08-29
+
+### Added
+
+- strategy-kit package providing typed models, strategy interfaces, a plugin registry, and an SMA crossover example. (T08)

--- a/packages/strategy-kit/README.md
+++ b/packages/strategy-kit/README.md
@@ -1,0 +1,19 @@
+# strategy-kit
+
+Reusable strategy interfaces, models, and utilities for Kitepilot.
+
+## Quickstart
+
+```bash
+pip install -e packages/strategy-kit
+```
+
+```python
+from strategy_kit.strategies.sma_crossover import SmaCrossoverStrategy
+from strategy_kit.examples.sma_crossover_runner import generate_bars
+
+strategy = SmaCrossoverStrategy(short_window=3, long_window=5)
+for bar in generate_bars():
+    for signal in strategy.on_bar(bar):
+        print(signal)
+```

--- a/packages/strategy-kit/pyproject.toml
+++ b/packages/strategy-kit/pyproject.toml
@@ -1,0 +1,29 @@
+[build-system]
+requires = ["hatchling>=1.18"]
+build-backend = "hatchling.build"
+
+[project]
+name = "strategy-kit"
+version = "0.1.0"
+description = "Strategy interfaces and utilities for Kitepilot"
+readme = "README.md"
+requires-python = ">=3.11"
+authors = [{name="Kitepilot"}]
+license = {text = "Apache-2.0"}
+dependencies = [
+  "pydantic>=2.7,<3",
+]
+
+[tool.hatch.build]
+packages = ["src/strategy_kit"]
+
+[tool.ruff]
+line-length = 100
+
+[tool.black]
+line-length = 100
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+packages = ["strategy_kit"]

--- a/packages/strategy-kit/src/strategy_kit/__init__.py
+++ b/packages/strategy-kit/src/strategy_kit/__init__.py
@@ -1,0 +1,21 @@
+"""strategy-kit public API."""
+
+from .interfaces import DataSource, PositionSizer, RiskManager, Strategy
+from .models import Bar, OrderSignal, Position, Side, Tick
+from .registry import get_strategy, register_strategy
+
+__all__ = [
+    "Bar",
+    "OrderSignal",
+    "Position",
+    "Side",
+    "Tick",
+    "DataSource",
+    "Strategy",
+    "PositionSizer",
+    "RiskManager",
+    "register_strategy",
+    "get_strategy",
+]
+
+__version__ = "0.1.0"

--- a/packages/strategy-kit/src/strategy_kit/examples/sma_crossover_runner.py
+++ b/packages/strategy-kit/src/strategy_kit/examples/sma_crossover_runner.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Iterator
+
+from strategy_kit.models import Bar
+from strategy_kit.strategies.sma_crossover import SmaCrossoverStrategy
+
+
+PRICES = [1, 2, 3, 4, 5, 6, 7, 6, 5, 4, 3]
+
+
+def generate_bars() -> Iterator[Bar]:
+    start = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    for i, price in enumerate(PRICES):
+        ts = start + timedelta(minutes=i)
+        yield Bar(
+            instrument="TEST",
+            start=ts,
+            end=ts + timedelta(minutes=1),
+            open=Decimal(price),
+            high=Decimal(price),
+            low=Decimal(price),
+            close=Decimal(price),
+            volume=100,
+        )
+
+
+def main() -> None:
+    strategy = SmaCrossoverStrategy(short_window=3, long_window=5)
+    for bar in generate_bars():
+        for signal in strategy.on_data(bar):
+            print(signal.model_dump_json())
+
+
+if __name__ == "__main__":  # pragma: no cover - manual run
+    main()

--- a/packages/strategy-kit/src/strategy_kit/interfaces.py
+++ b/packages/strategy-kit/src/strategy_kit/interfaces.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Iterable, Protocol
+
+from .models import Bar, OrderSignal, Position, Tick
+
+
+class DataSource(Protocol):
+    """Produces market data events for strategies."""
+
+    def stream(self) -> Iterable[Bar | Tick]:  # pragma: no cover - protocol method
+        """Return an iterable of market data events."""
+
+
+class Strategy(ABC):
+    """Base strategy interface."""
+
+    @abstractmethod
+    def on_data(self, data: Bar | Tick) -> list[OrderSignal]:
+        """Consume a bar or tick and optionally emit order signals."""
+
+
+class PositionSizer(Protocol):
+    """Determines order quantities based on strategy signals and current positions."""
+
+    def size_order(
+        self, signal: OrderSignal, position: Position
+    ) -> OrderSignal:  # pragma: no cover
+        """Return a sized order signal."""
+
+
+class RiskManager(Protocol):
+    """Approves or rejects signals based on risk constraints."""
+
+    def approve(self, signal: OrderSignal, position: Position) -> bool:  # pragma: no cover
+        """Return True if the order may proceed."""

--- a/packages/strategy-kit/src/strategy_kit/models.py
+++ b/packages/strategy-kit/src/strategy_kit/models.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from enum import Enum
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class Side(str, Enum):
+    """Order side."""
+
+    BUY = "BUY"
+    SELL = "SELL"
+
+
+class Tick(BaseModel):
+    """Market data tick."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    ts: datetime
+    instrument: str
+    price: Decimal
+    bid: Decimal | None = None
+    ask: Decimal | None = None
+    qty: int = 0
+
+    @field_validator("ts")
+    @classmethod
+    def ensure_aware(cls, v: datetime) -> datetime:
+        return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
+
+
+class Bar(BaseModel):
+    """OHLCV bar."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    instrument: str
+    start: datetime
+    end: datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: int = 0
+
+    @field_validator("start", "end")
+    @classmethod
+    def ensure_aware(cls, v: datetime) -> datetime:
+        return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
+
+
+class OrderSignal(BaseModel):
+    """Signal emitted by a strategy to express trading intent."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    instrument: str
+    side: Side
+    size: int = Field(gt=0)
+    ts: datetime
+
+    @field_validator("ts")
+    @classmethod
+    def ensure_aware(cls, v: datetime) -> datetime:
+        return v if v.tzinfo else v.replace(tzinfo=timezone.utc)
+
+
+class Position(BaseModel):
+    """Current position for an instrument."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    instrument: str
+    qty: int = 0
+    avg_price: Decimal = Decimal("0")

--- a/packages/strategy-kit/src/strategy_kit/registry.py
+++ b/packages/strategy-kit/src/strategy_kit/registry.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Dict, Type
+
+from .interfaces import Strategy
+
+_REGISTRY: Dict[str, Type[Strategy] | str] = {}
+
+
+def register_strategy(slug: str, target: Type[Strategy] | str) -> None:
+    """Register a strategy class or import path under *slug*."""
+
+    _REGISTRY[slug] = target
+
+
+def get_strategy(slug: str) -> Type[Strategy]:
+    """Return the strategy class registered under *slug*.
+
+    Supports lazy loading when an import path string was registered.
+    """
+
+    target = _REGISTRY.get(slug)
+    if target is None:
+        raise KeyError(f"strategy '{slug}' not found")
+    if isinstance(target, str):
+        module_name, class_name = target.rsplit(".", 1)
+        module = import_module(module_name)
+        cls = getattr(module, class_name)
+        if not issubclass(cls, Strategy):  # pragma: no cover - defensive programming
+            raise TypeError(f"{cls!r} is not a Strategy")
+        _REGISTRY[slug] = cls
+        return cls
+    return target

--- a/packages/strategy-kit/src/strategy_kit/strategies/sma_crossover.py
+++ b/packages/strategy-kit/src/strategy_kit/strategies/sma_crossover.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from collections import deque
+from typing import Deque, Dict, List
+
+from ..interfaces import Strategy
+from ..models import Bar, OrderSignal, Side
+from ..registry import register_strategy
+
+
+class SmaCrossoverStrategy(Strategy):
+    """Simple moving-average crossover strategy.
+
+    Emits a BUY signal when the short SMA crosses above the long SMA and a SELL
+    signal when it crosses below.
+    """
+
+    def __init__(self, *, short_window: int, long_window: int) -> None:
+        if short_window >= long_window:
+            raise ValueError("short_window must be < long_window")
+        self.short_window = short_window
+        self.long_window = long_window
+        self._short: Dict[str, Deque[float]] = {}
+        self._long: Dict[str, Deque[float]] = {}
+        self._last_rel: Dict[str, int] = {}
+
+    def on_data(self, data: Bar | object) -> List[OrderSignal]:
+        if not isinstance(data, Bar):
+            return []
+        short_q = self._short.setdefault(data.instrument, deque(maxlen=self.short_window))
+        long_q = self._long.setdefault(data.instrument, deque(maxlen=self.long_window))
+        last_rel = self._last_rel.get(data.instrument, 0)
+        short_q.append(float(data.close))
+        long_q.append(float(data.close))
+        if len(long_q) < self.long_window:
+            return []
+        short_avg = sum(short_q) / len(short_q)
+        long_avg = sum(long_q) / len(long_q)
+        rel = 1 if short_avg > long_avg else (-1 if short_avg < long_avg else 0)
+        signals: List[OrderSignal] = []
+        if last_rel <= 0 and rel > 0:
+            signals.append(
+                OrderSignal(
+                    instrument=data.instrument,
+                    side=Side.BUY,
+                    size=1,
+                    ts=data.end,
+                )
+            )
+        elif last_rel >= 0 and rel < 0:
+            signals.append(
+                OrderSignal(
+                    instrument=data.instrument,
+                    side=Side.SELL,
+                    size=1,
+                    ts=data.end,
+                )
+            )
+        self._last_rel[data.instrument] = rel
+        return signals
+
+
+register_strategy("sma_crossover", "strategy_kit.strategies.sma_crossover.SmaCrossoverStrategy")

--- a/packages/strategy-kit/tests/data/sma_crossover_expected.json
+++ b/packages/strategy-kit/tests/data/sma_crossover_expected.json
@@ -1,0 +1,14 @@
+[
+  {
+    "instrument": "TEST",
+    "side": "BUY",
+    "size": 1,
+    "ts": "2024-01-01T00:05:00+00:00"
+  },
+  {
+    "instrument": "TEST",
+    "side": "SELL",
+    "size": 1,
+    "ts": "2024-01-01T00:10:00+00:00"
+  }
+]

--- a/packages/strategy-kit/tests/unit/test_models.py
+++ b/packages/strategy-kit/tests/unit/test_models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from strategy_kit.models import Bar, OrderSignal, Position, Side, Tick
+
+
+def test_tick_validation_and_schema() -> None:
+    t = Tick(ts=datetime(2024, 1, 1, 12, 0), instrument="X", price=Decimal("1"))
+    assert t.ts.tzinfo is not None
+    schema = Tick.model_json_schema()
+    assert "instrument" in schema["properties"]
+
+
+def test_order_signal() -> None:
+    sig = OrderSignal(
+        instrument="X",
+        side=Side.BUY,
+        size=1,
+        ts=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+    )
+    assert sig.size == 1
+
+
+def test_position() -> None:
+    pos = Position(instrument="X", qty=2, avg_price=Decimal("3"))
+    assert pos.qty == 2 and pos.avg_price == Decimal("3")
+
+
+def test_bar_validation() -> None:
+    b = Bar(
+        instrument="X",
+        start=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        end=datetime(2024, 1, 1, 0, 1, tzinfo=timezone.utc),
+        open=Decimal("1"),
+        high=Decimal("2"),
+        low=Decimal("0.5"),
+        close=Decimal("1.5"),
+        volume=100,
+    )
+    assert b.end > b.start
+    with pytest.raises(ValueError):
+        OrderSignal(
+            instrument="X",
+            side=Side.BUY,
+            size=0,
+            ts=datetime(2024, 1, 1, tzinfo=timezone.utc),
+        )

--- a/packages/strategy-kit/tests/unit/test_registry.py
+++ b/packages/strategy-kit/tests/unit/test_registry.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from strategy_kit.interfaces import Strategy
+from strategy_kit.registry import get_strategy, register_strategy
+
+
+class DummyStrategy(Strategy):
+    def on_data(self, data):  # pragma: no cover - trivial
+        return []
+
+
+def test_register_and_get() -> None:
+    register_strategy("dummy", DummyStrategy)
+    assert get_strategy("dummy") is DummyStrategy
+
+
+def test_lazy_import() -> None:
+    register_strategy("lazy", "strategy_kit.strategies.sma_crossover.SmaCrossoverStrategy")
+    cls = get_strategy("lazy")
+    assert cls.__name__ == "SmaCrossoverStrategy"
+
+    with pytest.raises(KeyError):
+        get_strategy("missing")

--- a/packages/strategy-kit/tests/unit/test_runner.py
+++ b/packages/strategy-kit/tests/unit/test_runner.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from strategy_kit.models import OrderSignal
+
+
+def test_runner_smoke(tmp_path) -> None:
+    script = (
+        Path(__file__).parents[2] / "src" / "strategy_kit" / "examples" / "sma_crossover_runner.py"
+    )
+    proc = subprocess.run([sys.executable, str(script)], capture_output=True, check=True, text=True)
+    lines = [json.loads(line) for line in proc.stdout.strip().splitlines() if line.strip()]
+    assert lines  # at least one signal
+    for line in lines:
+        OrderSignal.model_validate(line)

--- a/packages/strategy-kit/tests/unit/test_sma_crossover.py
+++ b/packages/strategy-kit/tests/unit/test_sma_crossover.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from strategy_kit.examples.sma_crossover_runner import generate_bars
+from strategy_kit.models import OrderSignal
+from strategy_kit.strategies.sma_crossover import SmaCrossoverStrategy
+
+
+def test_sma_crossover_golden() -> None:
+    strategy = SmaCrossoverStrategy(short_window=3, long_window=5)
+    signals: list[OrderSignal] = []
+    for bar in generate_bars():
+        signals.extend(strategy.on_data(bar))
+    expected_path = Path(__file__).parents[1] / "data" / "sma_crossover_expected.json"
+    expected_raw = json.loads(expected_path.read_text())
+    expected = [OrderSignal.model_validate(e) for e in expected_raw]
+    assert [s.model_dump() for s in signals] == [s.model_dump() for s in expected]


### PR DESCRIPTION
## Summary
- introduce strategy-kit package with models, interfaces, registry, and SMA crossover strategy
- add example runner and CI wiring
## Acceptance Criteria
- [x] Create package with pyproject and version export
- [x] Define DataSource, Strategy, PositionSizer, RiskManager interfaces
- [x] Implement Bar, Tick, OrderSignal, Position models with JSON schema tests
- [x] Add registry with register/get and lazy import
- [x] Provide sma_crossover strategy and deterministic runner
- [x] Add unit tests and runner smoke test
- [x] Update CI to run mypy and pytest for strategy-kit
## Tests
- `ruff check packages/strategy-kit`
- `mypy packages/strategy-kit`
- `pytest -q packages/strategy-kit/tests`
- `pytest -q packages/common/tests packages/feature-lib/tests`
- `python -m bandit -q -r packages/strategy-kit`
## Performance/Security
- Deterministic examples; bandit reports only low-severity test assertions
## Migration/Deployment
- Additive package; no migrations
## Checklist
- [x] Lint & format pass locally
- [x] Tests pass locally
- [x] No secrets committed
- [x] Docs updated
- [x] Backwards compatibility verified


------
https://chatgpt.com/codex/tasks/task_e_68b28f7ea338833085432be79c00d632